### PR TITLE
Added "index terms" to indicate a key words section.

### DIFF
--- a/cermine-impl/pom.xml
+++ b/cermine-impl/pom.xml
@@ -12,6 +12,10 @@
     <packaging>jar</packaging>
     <name>CERMINE Engine Implementation - ${project.version}</name>
 
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
     <profiles>
         <profile>
             <id>full</id>

--- a/cermine-impl/src/main/java/pl/edu/icm/cermine/metadata/extraction/enhancers/KeywordsEnhancer.java
+++ b/cermine-impl/src/main/java/pl/edu/icm/cermine/metadata/extraction/enhancers/KeywordsEnhancer.java
@@ -32,7 +32,7 @@ import pl.edu.icm.cermine.structure.model.*;
  */
 public class KeywordsEnhancer extends AbstractSimpleEnhancer {
 
-    private static final Pattern PREFIX = Pattern.compile("^key\\s?words[:-]?", Pattern.CASE_INSENSITIVE);
+    private static final Pattern PREFIX = Pattern.compile("^key\\s?words[:-—]?|^index terms[:-—]?", Pattern.CASE_INSENSITIVE);
 
     public KeywordsEnhancer() {
         setSearchedZoneLabels(EnumSet.of(BxZoneLabel.MET_KEYWORDS));

--- a/cermine-impl/src/main/java/pl/edu/icm/cermine/metadata/zoneclassification/features/KeywordsFeature.java
+++ b/cermine-impl/src/main/java/pl/edu/icm/cermine/metadata/zoneclassification/features/KeywordsFeature.java
@@ -30,7 +30,7 @@ public class KeywordsFeature extends FeatureCalculator<BxZone, BxPage> {
 
     @Override
     public double calculateFeatureValue(BxZone zone, BxPage page) {
-        String[] keywords = {"keywords", "key words"};
+        String[] keywords = {"keywords", "key words", "index terms"};
 
         for (String keyword : keywords) {
             if (zone.toText().toLowerCase().startsWith(keyword)) {


### PR DESCRIPTION
The "key words" section is often indicated by "Index Terms". This modification takes that into account. Also, the character "—" is sometimes used as a separator. E.g., "Index Terms—inpainting, patch-based, ...". Therefore, the pom is modified to read the source as UTF-8 encoded text.