### PR TITLE
Added some new options and parallelization for ContentExtractor 

### DIFF
--- a/cermine-impl/src/main/java/pl/edu/icm/cermine/CommandLineOptionsParser.java
+++ b/cermine-impl/src/main/java/pl/edu/icm/cermine/CommandLineOptionsParser.java
@@ -38,6 +38,10 @@ public class CommandLineOptionsParser {
     public CommandLineOptionsParser() {
         options = new Options();
         options.addOption("path", true, "file or directory path");
+        options.addOption("start", true, "start point");
+        options.addOption("stop", true, "stop point");
+        options.addOption("workers", true, "number of workers");
+        options.addOption("outpath", true, "file or directory path for output");
         options.addOption("outputs", true, "types of the output");
         options.addOption("exts", true, "extensions of the output files");
         options.addOption("ext", true, "metadata file extension");
@@ -55,7 +59,7 @@ public class CommandLineOptionsParser {
         if (commandLine.getOptionValue("path") == null) {
             return "\"path\" parameter not specified";
         }
-        
+
         String output = commandLine.getOptionValue("outputs");
         String exts = commandLine.getOptionValue("exts");
         if (output != null) {
@@ -75,6 +79,53 @@ public class CommandLineOptionsParser {
     public String getPath() {
         return commandLine.getOptionValue("path");
     }
+
+    public String getOutPath() {
+        if (!commandLine.hasOption("outpath")) {
+            return commandLine.getOptionValue("path");
+        } else {
+            return commandLine.getOptionValue("outpath");
+        }
+    }
+
+    public Long getStart() {
+        if (!commandLine.hasOption("start")) {
+            return 0L;
+        } else {
+            Long value = Long.parseLong(commandLine.getOptionValue("start"));
+            if (value < 0) {
+                throw new RuntimeException("The 'start' value given as a " 
+                        + "command line parameter has to be nonnegative.");
+            }
+            return value;
+        }
+    }
+
+    public Long getStop() {
+        if (!commandLine.hasOption("stop")) {
+            return null;
+        } else {
+            Long value = Long.parseLong(commandLine.getOptionValue("stop"));
+            if (value < 0) {
+                throw new RuntimeException("The 'stop' value given as a " 
+                        + "command line parameter has to be nonnegative.");
+            }
+            return value;
+        }
+    }
+
+    public Long getWorkers() {
+        if (!commandLine.hasOption("workers")) {
+            return 1L;
+        } else {
+            Long value = Long.parseLong(commandLine.getOptionValue("workers"));
+            if (value <= 0) {
+                throw new RuntimeException("The 'workers' value given as a " 
+                        + "command line parameter has to be nonnegative.");
+            }
+            return value;
+        }
+    }
     
     public Map<String, String> getTypesAndExtensions() {
         Map<String, String> typesAndExts = new HashMap<String, String>();
@@ -84,7 +135,7 @@ public class CommandLineOptionsParser {
         typesAndExts.put("trueviz", "cermstr");
         typesAndExts.put("images", "images");
 
-        String[] types = getStringOptionValue("jats,images", "outputs").split(",");
+        String[] types = getStringOptionValue("jats", "outputs").split(",");
         for (String type: Lists.newArrayList(typesAndExts.keySet())) {
             if (!ArrayUtils.contains(types, type)) {
                 typesAndExts.remove(type);

--- a/cermine-impl/src/main/java/pl/edu/icm/cermine/ContentExtractor.java
+++ b/cermine-impl/src/main/java/pl/edu/icm/cermine/ContentExtractor.java
@@ -841,7 +841,7 @@ public class ContentExtractor {
                         }catch (IOException ex) {
                             printException(ex);
                         }catch (Exception ex) {
-                            System.out.println("OOps..........");
+                            printException(ex);
                         } finally {
                             if (extractor != null) {
                                 extractor.removeTimeout();
@@ -885,10 +885,10 @@ public class ContentExtractor {
                     + "Tool for extracting metadata and content from PDF files.\n\n"
                     + "Arguments:\n"
                     + "  -path <path>           path to a directory containing PDF files\n"
-                    + "  -start <int>           which point to start parsing the PDF files\n"
-                    + "  -stop <int>            which point to stop parsing the PDF files\n"
-                    + "  -workers <int>         how many workers to run in parallel\n"
-                    + "  -outpath <path>        path to a directory to write the resulting files\n"
+                    + "  -start <int>           (optional) which point to start parsing the PDF files  default: \"beginning\"\n"
+                    + "  -stop <int>            (optional) which point to stop parsing the PDF files  default: \"end\"\n"
+                    + "  -workers <int>         (optional) how many workers to run in parallel  default: \"1\"\n"
+                    + "  -outpath <path>        (optional) path to a directory to write the resulting files  default: \"-path\"\n"
                     + "  -outputs <list>        (optional) comma-separated list of extraction\n"
                     + "                         output(s); possible values: \"jats\" (document\n"
                     + "                         metadata and content in NLM JATS format), \"text\"\n"


### PR DESCRIPTION
I modified the code to enable running parallel parsers at once in order to speed-up the extraction when there is a large number of files to be extracted. The new options added are:

1. -start and -stop : To enable extraction between ranges of files. By default, this includes all the files in the folder as in the original algorithm.
2. -outpath : The output file to write the resulting files and folders. By default, this is the same path as the input path as in the original algorithm.
3. -workers : The number of content extraction workers to run in parallel. This divides the files equally among the workers. By default, this is "1" as in the original algorithm. The parallelism is implemented using java threads.

P.S: I made the default output option to be just "jats" as some people might not be interested in extracting the images.

P.P.S: Let me know if you need any more clarification. Thanks