### PR TITLE
Fix issue #64: uncovertible images

### DIFF
--- a/cermine-impl/src/main/java/pl/edu/icm/cermine/structure/ITextCharacterExtractor.java
+++ b/cermine-impl/src/main/java/pl/edu/icm/cermine/structure/ITextCharacterExtractor.java
@@ -109,7 +109,12 @@ public class ITextCharacterExtractor implements CharacterExtractor {
                 processAlternativeColorSpace(resources);
 
                 processor.reset();
-                processor.processContent(ContentByteUtils.getContentBytesForPage(reader, pageNumber), resources);
+                try {
+                  processor.processContent(ContentByteUtils.getContentBytesForPage(reader, pageNumber), resources);
+                } catch (com.itextpdf.text.ExceptionConverter ex) {
+                  System.out.println("Failed to parse page" + pageNumber + " ... skipping page!");
+                  continue;
+                }
                 TimeoutRegister.get().check();
             }
 


### PR DESCRIPTION
When iText.text.pdf.parser fails to parse/convert an image, CERMINE
fails to catch the exception and crashes. This patch catches the
exception, reports it, and skips the page with the unconvertible image
(continue to parse the rest of the pages).

See issue #64: https://github.com/CeON/CERMINE/issues/64