### PR TITLE
Add support for DOI url detection

### DIFF
--- a/cermine-impl/src/main/java/pl/edu/icm/cermine/metadata/extraction/enhancers/DoiEnhancer.java
+++ b/cermine-impl/src/main/java/pl/edu/icm/cermine/metadata/extraction/enhancers/DoiEnhancer.java
@@ -36,6 +36,7 @@ public class DoiEnhancer extends AbstractMultiPatternEnhancer {
 
     private static final List<Pattern> PATTERNS = Lists.newArrayList(
             Pattern.compile("\\bdoi:?\\s*(" + PatternUtils.DOI_PATTERN + ")", Pattern.CASE_INSENSITIVE),
+            Pattern.compile("\\bhttps://doi.org/(" + PatternUtils.DOI_PATTERN + ")", Pattern.CASE_INSENSITIVE),
             Pattern.compile("\\bdx\\.doi\\.org/(" + PatternUtils.DOI_PATTERN + ")", Pattern.CASE_INSENSITIVE)
             );
     private static final Set<BxZoneLabel> SEARCHED_ZONE_LABELS = EnumSet.of(BxZoneLabel.MET_BIB_INFO);


### PR DESCRIPTION
Adds an additional regex to detect DOIs when they are present in the form of https://doi.org/whatever

Elsevier PDFs seem to use this format